### PR TITLE
Feat/set instance initiated shutdown to terminate

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -61,6 +61,7 @@ async function startEc2Instance(label, githubRegistrationToken) {
     SecurityGroupIds: [config.input.securityGroupId],
     IamInstanceProfile: { Name: config.input.iamRoleName },
     TagSpecifications: config.tagSpecifications,
+    InstanceInitiatedShutdownBehavior: 'terminate',
     MetadataOptions: {
       HttpTokens: 'required',
       HttpEndpoint: 'enabled',


### PR DESCRIPTION
This PR changes the behaviour for EC2 instances such that they are terminated (rather than stopped) when shutdown from within the instances own OS

Related to https://github.com/PMO-Data-Science/10ds-core-github-actions/pull/52/files