### PR TITLE
Bump action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,5 +86,5 @@ outputs:
       EC2 Instance Id of the created runner.
       The id is used to terminate the EC2 instance when the runner is not needed anymore.
 runs:
-  using: node20
+  using: node24
   main: ./dist/index.js


### PR DESCRIPTION
## Summary

- Updates `action.yml` to declare `using: node24` instead of `using: node20`
- Required ahead of GitHub's Node 20 deprecation on Actions runners (Phase 3: September 16, 2026)
- No changes to compiled `dist/index.js` — Node 24 is backwards compatible with the existing code

## Test plan

- Tested against our own workflows pointing at this branch — build ran cleanly with no Node 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)